### PR TITLE
scons 3.0 compatibility fixes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -22,7 +22,7 @@ from subprocess import Popen, PIPE
 import coda
 
 # Created files & dirs will have this permission
-os.umask(002)
+os.umask(0o2)
 
 # Software version
 versionMajor = '5'
@@ -41,13 +41,13 @@ ldLibPath = os.getenv('LD_LIBRARY_PATH', '')
 
 if path == '':
     print
-    print "Error: set PATH environmental variable"
+    print ("Error: set PATH environmental variable")
     print
     raise SystemExit
 
 if ldLibPath == '':
     print
-    print "Warning: LD_LIBRARY_PATH environmental variable not defined"
+    print ("Warning: LD_LIBRARY_PATH environmental variable not defined")
     print
     env = Environment(ENV = {'PATH' : os.environ['PATH']})
 else:
@@ -64,9 +64,9 @@ else:
 # a configure-type test.
 is64bits = coda.is64BitMachine(env, platform, machine)
 if is64bits:
-    print "We're on a 64-bit machine"
+    print ("We're on a 64-bit machine")
 else:
-    print "We're on a 32-bit machine"
+    print ("We're on a 32-bit machine")
 
 
 #############################################
@@ -79,13 +79,13 @@ Help('\nlocal scons OPTIONS:\n')
 # debug option
 AddOption('--dbg', dest='ddebug', default=False, action='store_true')
 debug = GetOption('ddebug')
-if debug: print "Enable debugging"
+if debug: print ("Enable debugging")
 Help('--dbg               compile with debug flag\n')
 
 # 32 bit option
 AddOption('--32bits', dest='use32bits', default=False, action='store_true')
 use32bits = GetOption('use32bits')
-if use32bits: print "use 32-bit libs & executables even on 64 bit system"
+if use32bits: print ("use 32-bit libs & executables even on 64 bit system")
 Help('--32bits            compile 32bit libs & executables on 64bit system\n')
 
 # install directory option
@@ -148,7 +148,7 @@ if platform == 'Darwin':
 if is64bits and use32bits:
     osname = osname + '-32'
 
-print "OSNAME =", osname
+print ("OSNAME = "+osname)
 
 # hidden sub directory into which variant builds go
 archDir = '.' + osname + debugSuffix
@@ -185,13 +185,13 @@ if 'install' in COMMAND_LINE_TARGETS:
     # Create the include directories (make symbolic link if possible)
     coda.makeIncludeDirs(incInstallDir, archIncInstallDir, osDir, archIncLocalLink)
 
-    print 'Main install dir  = ', mainInstallDir
-    print 'bin  install dir  = ', binInstallDir
-    print 'lib  install dir  = ', libInstallDir
-    print 'inc  install dirs = ', incInstallDir, ", ", archIncInstallDir
+    print ('Main install dir  = '+mainInstallDir)
+    print ('bin  install dir  = '+binInstallDir)
+    print ('lib  install dir  = '+libInstallDir)
+    print ('inc  install dirs = '+incInstallDir+", "+archIncInstallDir)
 
 else:
-    print 'No installation being done'
+    print ('No installation being done')
 
 print
 

--- a/coda.py
+++ b/coda.py
@@ -101,7 +101,7 @@ def is64BitMachine(env, platform, machine):
         ret = conf.CheckBits(ccflags)
         env = conf.Finish()
         if ret < 1:
-            print 'Cannot run test, assume 64 bit system'
+            print ('Cannot run test, assume 64 bit system')
             return True
         elif ret == 64:
             # Test shows 64 bit system'
@@ -153,8 +153,8 @@ def getInstallationDirs(osname, prefix, incdir, libdir, bindir):
         # prefix not defined try CODA env var
         if codaHomeEnv == "":
             if (incdir == None) or (libdir == None) or (bindir == None):
-                print "\nNeed to define CODA, or use the --prefix option,"
-                print "or all the --incdir, --libdir, and --bindir options.\n"
+                print ("\nNeed to define CODA, or use the --prefix option,")
+                print ("or all the --incdir, --libdir, and --bindir options.\n")
                 raise SystemExit
         else:
             prefix = codaHomeEnv
@@ -203,7 +203,7 @@ def makeIncludeDirs(includeDir, archIncludeDir, archDir, archIncLocalLink):
     # Make sure it's a directory (if we didn't create it)
     elif not os.path.isdir(includeDir):
         print
-        print "Error:", includeDir, "is NOT a directory"
+        print ("Error:", includeDir, "is NOT a directory")
         print
         raise SystemExit
 
@@ -221,7 +221,7 @@ def makeIncludeDirs(includeDir, archIncludeDir, archDir, archIncLocalLink):
             return
     elif not os.path.isdir(archDir):
         print
-        print "Error:", archDir, "is NOT a directory"
+        print ("Error:", archDir, "is NOT a directory")
         print
         raise SystemExit
 
@@ -232,17 +232,17 @@ def makeIncludeDirs(includeDir, archIncludeDir, archDir, archIncLocalLink):
     if not os.path.exists(archIncludeDir):
         # Create symbolic link: symlink(source, linkname)
         try:
-    	    if (archIncLocalLink == None) or (archIncLocalLink == ''):
-	    	symlink(includeDir, archIncludeDir)
+            if (archIncLocalLink == None) or (archIncLocalLink == ''):
+                symlink(includeDir, archIncludeDir)
             else:
-	    	symlink(archIncLocalLink, archIncludeDir)
+                symlink(archIncLocalLink, archIncludeDir)
         except OSError:
             # Failed to create symbolic link, so
             # just make it a regular directory
             os.makedirs(archIncludeDir)
     elif not os.path.isdir(archIncludeDir):
         print
-        print "Error:", archIncludeDir, "is NOT a directory"
+        print ("Error:", archIncludeDir, "is NOT a directory")
         print
         raise SystemExit
 
@@ -266,18 +266,18 @@ def configureJNI(env):
             java_base = '/System/Library/Frameworks/JavaVM.framework'
         else:
             # Search for the java compiler
-            print "JAVA_HOME environment variable not set. Searching for javac to find jni.h ..."
+            print ("JAVA_HOME environment variable not set. Searching for javac to find jni.h ...")
             if not env.get('JAVAC'):
-                print "The Java compiler must be installed and in the current path, exiting"
+                print ("The Java compiler must be installed and in the current path, exiting")
                 return 0
             jcdir = os.path.dirname(env.WhereIs('javac'))
             if not jcdir:
-                print "   not found, exiting"
+                print ("   not found, exiting")
                 return 0
             # assuming the compiler found is in some directory like
             # /usr/jdkX.X/bin/javac, java's home directory is /usr/jdkX.X
             java_base = os.path.join(jcdir, "..")
-            print "  found, dir = " + java_base        
+            print ("  found, dir = " + java_base)
         
     if sys.platform == 'darwin':
         # Apple does not use Sun's naming convention


### PR DESCRIPTION
 scons 3.0 uses python3.  Python 3 doesn't like some things.
  1.  print statements without parens around the stuff
  2.  The old octal number format (Use 0o prefix instead of 0)
  3.  Tab characters in the indentation.