### PR TITLE
Check buffer/segment length vs. buffer length in swap_data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,8 @@ endif()
 # Shared evio C library
 add_library(evio SHARED ${C_LIB_FILES})
 set_target_properties(evio PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+target_compile_options(evio PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/Wall>
+  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall -Wextra -Wno-unused-parameter>)
 include_directories(evio PUBLIC src/libsrc /usr/local/include)
 
 
@@ -168,6 +170,8 @@ if (NOT C_ONLY)
     # Shared evio C++ library
     add_library(eviocc SHARED ${CPP_LIB_FILES})
     set_target_properties(eviocc PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+    target_compile_options(eviocc PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/Wall>
+      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall -Wextra -Wno-unused-parameter>)
     target_link_libraries(eviocc expat evio)
     include_directories(eviocc PUBLIC src/libsrc src/libsrc++ /usr/local/include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ cmake_minimum_required(VERSION 3.3)
 
 project(evio VERSION 5.2)
 
+option(C_ONLY "Build C-library only" OFF)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -152,7 +153,7 @@ if( DOXYGEN_FOUND )
     doxygen_add_docs(docC src/libsrc )
 
 
-elseif(NOT DEFINED C_ONLY)
+elseif(NOT C_ONLY)
     message(FATAL_ERROR "Doxygen NOT found, cmake will exit." )
 endif()
 
@@ -163,7 +164,7 @@ set_target_properties(evio PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
 include_directories(evio PUBLIC src/libsrc /usr/local/include)
 
 
-if (NOT DEFINED C_ONLY)
+if (NOT C_ONLY)
     # Shared evio C++ library
     add_library(eviocc SHARED ${CPP_LIB_FILES})
     set_target_properties(eviocc PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
@@ -222,7 +223,7 @@ if (DEFINED INSTALL_DIR_DEFINED)
     install(TARGETS evio LIBRARY DESTINATION lib)
     install(FILES ${C_HEADER_FILES} DESTINATION include)
 
-    if (NOT DEFINED C_ONLY)
+    if (NOT C_ONLY)
         install(TARGETS eviocc LIBRARY DESTINATION lib)
         install(FILES ${CPP_HEADER_FILES} DESTINATION include)
         install(FILES ${CPP_HEADER_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 cmake_minimum_required(VERSION 3.3)
 
 
-project(evio VERSION 5.2)
+project(evio VERSION 5.2.1 LANGUAGES C CXX)
 
 option(C_ONLY "Build C-library only" OFF)
 

--- a/SConstruct
+++ b/SConstruct
@@ -27,9 +27,10 @@ os.umask(2)
 # Software version
 versionMajor = '5'
 versionMinor = '2'
+versionPatch = '1'
 
 # Determine the os and machine names
-uname    = os.uname();
+uname    = os.uname()
 platform = uname[0]
 machine  = uname[4]
 osname   = os.getenv('CODA_OSNAME', platform + '-' +  machine)
@@ -237,7 +238,7 @@ Help('undoc               remove javadoc (in ./doc)\n')
 #########################
 
 if 'tar' in COMMAND_LINE_TARGETS:
-    coda.generateTarFile(env, 'evio', versionMajor, versionMinor)
+    coda.generateTarFile(env, 'evio', versionMajor, versionMinor+'.'+versionPatch)
 
 # use "tar" on command line to create tar file
 Help('tar                 create tar file (in ./tar)\n')

--- a/src/libsrc/evio.c
+++ b/src/libsrc/evio.c
@@ -98,6 +98,8 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include "evio.h"
 
 
@@ -4656,7 +4658,7 @@ static int evWriteImpl(int handle, const uint32_t *buffer, int useMutex)
     bytesToWrite = 4 * wordsToWrite;
 
     if (debug && a->splitting) {
-printf("evWrite: splitting, bytesToFile = %llu, event bytes = %u, bytesToBuf = %u, split = %llu\n",
+printf("evWrite: splitting, bytesToFile = %"PRIu64", event bytes = %u, bytesToBuf = %u, split = %"PRIu64"\n",
                a->bytesToFile, bytesToWrite, a->bytesToBuf, a->split);
 printf("evWrite: blockNum = %u, (blkNum == 2) = %d, eventsToBuf (%u)  <=? common blk cnt (%u)\n",
        a->blknum, (a->blknum == 2),  a->eventsToBuf,  a->commonBlkCount);
@@ -4701,10 +4703,10 @@ if (debug) printf("evWrite: don't split file cause only common block written so 
         }
 
 if (debug) {
-    printf("evWrite: splitting = %s: total size = %llu >? split = %llu\n",
+    printf("evWrite: splitting = %s: total size = %"PRIu64" >? split = %"PRIu64"\n",
            (totalSize > a->split ? "True" : "False"), totalSize, a->split);
 
-    printf("evWrite: total size components: bytesToFile = %llu, bytesToBuf = %u, ev bytes = %u, dictlen = %u\n",
+    printf("evWrite: total size components: bytesToFile = %"PRIu64", bytesToBuf = %u, ev bytes = %u, dictlen = %u\n",
            a->bytesToFile, a->bytesToBuf, bytesToWrite, a->dictLength);
 }
 
@@ -4885,7 +4887,7 @@ if (debug) {
         printf("         common block cnt = %u\n", a->commonBlkCount);
         printf("         current block cnt (dict) = %u\n", a->blkEvCount);
         printf("         bytes-to-buf  = %u\n", a->bytesToBuf);
-        printf("         bytes-to-file = %llu\n", a->bytesToFile);
+        printf("         bytes-to-file = %"PRIu64"\n", a->bytesToFile);
         printf("         block # = %u\n", a->blknum);
 }
 
@@ -5125,7 +5127,7 @@ printf("    flushToFile: will not overwrite file = %s\n", a->fileName);
         printf("         internal buffer cnt (dict) = %u\n", a->eventsToBuf);
         printf("         current block cnt (dict) = %u\n", a->blkEvCount);
         printf("         bytes-written = %u\n", bytesToWrite);
-        printf("         bytes-to-file = %llu\n", a->bytesToFile);
+        printf("         bytes-to-file = %"PRIu64"\n", a->bytesToFile);
         printf("         block # = %u\n", a->blknum);
     }
 
@@ -5890,13 +5892,13 @@ if (debug) printf("evIoctl: increasing internal buffer size to %u words\n", buff
             /* Smallest possible evio format file = 10 32-bit ints.
              * Must also be bigger than a single buffer? */
             if (splitSize < 4*10) {
-if (debug) printf("evIoctl: split file size is too small! (%llu bytes), must be min 40\n", splitSize);
+if (debug) printf("evIoctl: split file size is too small! (%"PRIu64" bytes), must be min 40\n", splitSize);
                 handleUnlock(handle);
                 return(S_EVFILE_BADSIZEREQ);
             }
             
             a->split = splitSize;
-if (debug) printf("evIoctl: split file at %llu (0x%llx) bytes\n", splitSize, splitSize);
+if (debug) printf("evIoctl: split file at %"PRIu64" (0x%"PRIx64") bytes\n", splitSize, splitSize);
             break;
 
         /************************************************/

--- a/src/libsrc/evio.c
+++ b/src/libsrc/evio.c
@@ -3134,7 +3134,7 @@ if (debug) printf("toAppendPosition: last block had no data, back up 1 header to
 static int evReadAllocImplFileV3(EVFILE *a, uint32_t **buffer, uint32_t *buflen)
 {
     uint32_t *buf, *pBuf;
-    int       status;
+    int       status = S_SUCCESS;
     uint32_t  nleft, ncopy, len;
 
 
@@ -3190,14 +3190,14 @@ static int evReadAllocImplFileV3(EVFILE *a, uint32_t **buffer, uint32_t *buflen)
 
     /* Swap event in place if necessary */
     if (a->byte_swapped) {
-        evioswap(buf, 1, NULL);
+        status = evioswap(buf, 1, NULL);
     }
 
     /* Return allocated buffer with event inside and its inclusive len (with full header) */
     *buffer = buf;
     *buflen = len;
 
-    return(S_SUCCESS);
+    return(status);
 }
 
 
@@ -3227,7 +3227,7 @@ static int evReadAllocImplFileV3(EVFILE *a, uint32_t **buffer, uint32_t *buflen)
 static int evReadAllocImpl(EVFILE *a, uint32_t **buffer, uint32_t *buflen)
 {
     uint32_t *buf, *pBuf;
-    int       status;
+    int       status = S_SUCCESS;
     uint32_t  nleft, ncopy, len;
 
 
@@ -3303,14 +3303,14 @@ static int evReadAllocImpl(EVFILE *a, uint32_t **buffer, uint32_t *buflen)
 
     /* Swap event in place if necessary */
     if (a->byte_swapped) {
-        evioswap(buf, 1, NULL);
+        status = evioswap(buf, 1, NULL);
     }
 
     /* Return allocated buffer with event inside and its inclusive len (with full header) */
     *buffer = buf;
     *buflen = len;
     
-    return(S_SUCCESS);
+    return(status);
 }
 
 
@@ -3474,7 +3474,7 @@ static int evGetNewBufferFileV3(EVFILE *a)
  */
 static int evReadFileV3(EVFILE *a, uint32_t *buffer, uint32_t buflen)
 {
-    int       status,  swap;
+    int       status = S_SUCCESS,  swap;
     uint32_t  nleft, ncopy;
     uint32_t *temp_buffer=NULL, *temp_ptr=NULL;
 
@@ -3544,11 +3544,11 @@ static int evReadFileV3(EVFILE *a, uint32_t *buffer, uint32_t buflen)
     
     /* Swap event if necessary */
     if (swap) {
-        evioswap(temp_ptr, 1, buffer);
+        status = evioswap(temp_ptr, 1, buffer);
         free(temp_ptr);
     }
 
-    return(S_SUCCESS);
+    return(status);
 }
 
 
@@ -3577,7 +3577,7 @@ static int evReadFileV3(EVFILE *a, uint32_t *buffer, uint32_t buflen)
 int evRead(int handle, uint32_t *buffer, uint32_t buflen)
 {
     EVFILE   *a;
-    int       status,  swap;
+    int       status = S_SUCCESS,  swap;
     uint32_t  nleft, ncopy;
     uint32_t *temp_buffer=NULL, *temp_ptr=NULL;
 
@@ -3695,11 +3695,11 @@ int evRead(int handle, uint32_t *buffer, uint32_t buflen)
 
     /* Swap event if necessary */
     if (swap) {
-        evioswap(temp_ptr, 1, buffer);
+        status = evioswap(temp_ptr, 1, buffer);
         free(temp_ptr);
     }
 
-    return(S_SUCCESS);
+    return(status);
 }
 
 
@@ -3786,7 +3786,7 @@ int evReadAlloc(int handle, uint32_t **buffer, uint32_t *buflen)
 int evReadNoCopy(int handle, const uint32_t **buffer, uint32_t *buflen)
 {
     EVFILE    *a;
-    int       status;
+    int       status = S_SUCCESS;
     uint32_t  nleft;
 
 
@@ -3845,7 +3845,7 @@ int evReadNoCopy(int handle, const uint32_t **buffer, uint32_t *buflen)
         nleft = EVIO_SWAP32(*(a->next)) + 1;
                         
         /* swap data in block buffer */
-        evioswap(a->next, 1, NULL);
+        status = evioswap(a->next, 1, NULL);
     }
     else {
         /* Length of next bank, including header, in 32 bit words */
@@ -3861,7 +3861,7 @@ int evReadNoCopy(int handle, const uint32_t **buffer, uint32_t *buflen)
     
     handleUnlock(handle);
 
-    return(S_SUCCESS);
+    return(status);
 }
 
 
@@ -3897,7 +3897,7 @@ int evReadRandom(int handle, const uint32_t **pEvent, uint32_t *buflen, uint32_t
 {
     EVFILE   *a;
     uint32_t *pev;
-
+    int      status = S_SUCCESS;
     
     if (pEvent == NULL) {
         return(S_EVFILE_BADARG);
@@ -3953,7 +3953,7 @@ int evReadRandom(int handle, const uint32_t **pEvent, uint32_t *buflen, uint32_t
         *buflen = EVIO_SWAP32(*pev) + 1;
                         
         /* swap data in buf/mem-map buffer */
-        evioswap(pev, 1, NULL);
+        status = evioswap(pev, 1, NULL);
     }
     else {
         /* Length of bank, including header, in 32 bit words */
@@ -3965,7 +3965,7 @@ int evReadRandom(int handle, const uint32_t **pEvent, uint32_t *buflen, uint32_t
 
     handleUnlock(handle);
 
-    return(S_SUCCESS);
+    return(status);
 }
 
 
@@ -6908,7 +6908,11 @@ char *evPerror(int error) {
             sprintf(temp, "S_EVFILE_BADMODE:  invalid operation for current evOpen() mode\n");
             break;
 
-        default:
+        case S_EVFILE_BADHEADER:
+            sprintf(temp, "S_EVFILE_BADHEADER:  invalid data in bank or segment header\n");
+            break;
+
+      default:
             sprintf(temp, "?evPerror...no such error: %d\n",error);
             break;
     }

--- a/src/libsrc/evio.h
+++ b/src/libsrc/evio.h
@@ -57,6 +57,7 @@ extern "C" {
 #define S_EVFILE_BADSIZEREQ 0x80730006  /**< Invalid buffer size request to evIoct */
 #define S_EVFILE_BADARG     0x80730007  /**< Invalid function argument */
 #define S_EVFILE_BADMODE    0x80730008  /**< Wrong mode used in evOpen for this operation */
+#define S_EVFILE_BADHEADER  0x80730009  /**< Invalid data in bank or segment header */
 
 /**
  * @addtogroup swap
@@ -245,7 +246,7 @@ typedef struct evioBlockHeaderV4_t {
 /* prototypes */
 
 void set_user_frag_select_func( int32_t (*f) (int32_t tag) );
-void evioswap(uint32_t *buffer, int tolocal, uint32_t *dest);
+int evioswap(uint32_t *buffer, int tolocal, uint32_t *dest);
 uint16_t *swap_int16_t(uint16_t *data, unsigned int length, uint16_t *dest);
 uint32_t *swap_int32_t(uint32_t *data, unsigned int length, uint32_t *dest);
 uint64_t *swap_int64_t(uint64_t *data, unsigned int length, uint64_t *dest);

--- a/src/libsrc/eviofmtswap.c
+++ b/src/libsrc/eviofmtswap.c
@@ -78,12 +78,12 @@ typedef struct {
  * @return -1 if nwrd or nfmt arg(s) < 0
  */
 int
-eviofmtswap(int32_t *iarr, int nwrd, unsigned short *ifmt, int nfmt, int tolocal, int padding)
+eviofmtswap(int32_t *iarr, int nwrd, const unsigned short *ifmt, int nfmt, int tolocal, int padding)
 {
     int imt  = 0;   /* ifmt[] index */
     int ncnf = 0;   /* how many times must repeat a format */
     int lev  = 0;   /* parenthesis level */
-    int kcnf, mcnf, iterm = 0;
+    int kcnf, mcnf/*, iterm = 0*/;
     int64_t *b64, *b64end;
     int32_t *b32, *b32end;
     int16_t *b16, *b16end;

--- a/src/libsrc/evioswap.c
+++ b/src/libsrc/evioswap.c
@@ -78,7 +78,7 @@
 
 /* from Sergey's composite swap library */
 extern int eviofmt(char *fmt, unsigned short *ifmt, int ifmtLen);
-extern int eviofmtswap(uint32_t *iarr, int nwrd, unsigned short *ifmt, int nfmt, int tolocal, int padding);
+extern int eviofmtswap(uint32_t *iarr, int nwrd, const unsigned short *ifmt, int nfmt, int tolocal, int padding);
 
 /* internal prototypes */
 static int swap_bank(uint32_t *buf, int tolocal, uint32_t *dest);


### PR DESCRIPTION
Fix crashes due to random memory overwriting in swap_data if the length of a bank or segment determined from the header word is garbage. This can happen with corrupted input data written by buggy or misconfigured DAQ frontends. We've just seen this happen with SBS test data in Hall A. In general, it is good idea to validate all input data. This PR adds some such checks, which were previously missing.

The main commit in the PR is 97e051731d5fa2db5978dffb0c5aec8929c64c2b. I also added a portable fix for compiler warnings about some printf format fields and a few minor CMake tweaks. Verbose compiler warnings are now on by default. The project version has been incremented to 5.2.1 in CMake/SCons.

This is a PR for the evio-5.2 branch.