### PR TITLE
Update javadoc actions

### DIFF
--- a/.github/workflows/doc_generation-6.0.yml
+++ b/.github/workflows/doc_generation-6.0.yml
@@ -29,15 +29,19 @@ jobs:
           working-directory: '.'
           doxyfile-path: 'doc/doxygen/DoxyfileCC'
 
+      - name: Install Maven
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y maven
+          
       # generate the javadoc files
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
-          distribution: 'adopt'
-
+          java-version: '17'
+          distribution: 'temurin' 
       - name: Javadoc Action
-        run: ant -noinput -buildfile build.xml javadoc
+        run: mvn javadoc:javadoc
 
       # clean up the javadoc files including removing timestamps. OPTIONAL.
       - name: Tidy up the javadocs

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ It was created by the Data Acquisition (DAQ) group and is maintained by the
 Experimental Physics Software and Computing Infrastructure (EPSCI) group at Thomas 
 Jefferson National Accelerator Facility (JLab).
 
-This software repository allows one to read & write evio format data, within
-either a C/C++ or Java programming environment.
+This software repository allows one to read & write `.evio` and `.ev` format data, 
+within either a C/C++ or Java programming environment.
 
 # **Getting Started**
 
@@ -76,7 +76,7 @@ Software Library Documentation:
 * [Doxygen for C++ Libary](https://jeffersonlab.github.io/evio/doc-6.0/doxygen/CC/html/index.html)
 
 Other Links:
-*  [EVIO Event Viewer on GitHub](https://github.com/JeffersonLab/JEventViewer)
+* [EVIO Event Viewer on GitHub](https://github.com/JeffersonLab/JEventViewer)
 
 
 The EVIO-6 data format is closely related to the HIPO data format, following the same data

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,6 @@
     <plugin>
       <artifactId>maven-assembly-plugin</artifactId>
       <version>3.6.0</version>           <!-- upgrade to latest -->
-      
       <configuration>
         <!-- <appendAssemblyId>false</appendAssemblyId> -->
         <descriptorRefs>
@@ -160,6 +159,16 @@
       </configuration>
     </plugin>
 
+    <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.6.2</version>
+        <configuration>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
+            <reportOutputDirectory>doc/javadoc</reportOutputDirectory>
+        </configuration> 
+    </plugin>
 
   </plugins>
 

--- a/src/main/java/org/jlab/coda/jevio/CompositeData.java
+++ b/src/main/java/org/jlab/coda/jevio/CompositeData.java
@@ -1389,7 +1389,7 @@ public final class CompositeData implements Cloneable {
     /**
      *  This method transforms a composite, format-containing
      *  ASCII string to an int array. It is to be used in
-     *  conjunction with {@link #swapData(ByteBuffer, ByteBuffer, int, List)}
+     *  conjunction with {@link #swapData(ByteBuffer, ByteBuffer, int, int, List)}
      *  to swap the endianness of composite data.
      *  It's translated from the eviofmt C function.
      * <pre><code>

--- a/src/main/java/org/jlab/coda/jevio/Utilities.java
+++ b/src/main/java/org/jlab/coda/jevio/Utilities.java
@@ -223,66 +223,75 @@ final public class Utilities {
      * If evio data is to be split up into multiple files (split &gt; 0), numbers are used to
      * distinguish between the split files with splitNumber.</p>
      *
-     * <p>The given fileName may contain uyp to 3, C-style int format specifiers which will be substituted
+     * <p>The given fileName may contain up to 3, C-style int format specifiers which will be substituted
      * with runNumber, splitNumber and streamId in the manner described below.</p>
      *
      * <ul>
-     *     <li>If file is to be split:</li>
-     *          <ul>
-     *          <li>If no specifiers:</li>
-     *              <ul>
-     *                  <li>for one stream, splitNumber is tacked onto the end of the file name as <b>.&lt;splitNumber&gt;</b></li>
-     *                  <li>for multiple streams, streamId and splitNumber are tacked onto the end of the file name
-     *                      as <b>.&lt;streamId&gt;.&lt;splitNumber&gt;</b></li>
-     *                  <li>No run numbers are ever tacked on without a specifier </li>
-     *              </ul>
-     *          <li>If 1 specifier:</li>
-     *              <ul>
-     *                  <li>add runNumber according to specifier</li>
-     *                  <li>for one stream, splitNumber is tacked onto the end of the file name as <b>.&lt;splitNumber&gt;</b></li>
-     *                  <li>for multiple streams, streamId and splitNumber are tacked onto the end of the file name
-     *                      as <b>.&lt;streamId&gt;.&lt;splitNumber&gt;</b></li>
-     *              </ul>
-     *          <li>If 2 specifiers:</li>
-     *              <ul>
-     *                  <li>add runNumber according to first specifier</li>
-     *                  <li>for one stream, add splitNumber according to second specifier</li>
-     *                  <li>for multiple streams, add splitNumber according to second specifier, but place
-     *                      <b>&lt;streamId&gt;.</b> just before the splitNumber</li>
-     *              </ul>
-     *          <li>If 3 specifiers:</li>
-     *              <ul>
-     *                  <li>add runNumber according to first specifier</li>
-     *                  <li>add streamId according to second specifier add splitNumber according to third specifier</li>
-     *              </ul>
-     *          </ul>
-     *
-     *      <li>If file is NOT split:</li>
-     *          <ul>
-     *          <li>If no specifiers:</li>
-     *              <ul>
-     *                  <li>streamId is tacked onto the end of the file name as <b>.&lt;streamId&gt;</b></li>
-     *                  <li>No run numbers are ever tacked on without a specifier.</li>
-     *              </ul>
-     *          <li>If 1 specifier:</li>
-     *              <ul>
-     *                  <li>add runNumber according to specifier</li>
-     *                  <li>for multiple streams, streamId is tacked onto the end of the file name as .<b>.&lt;streamId&gt;</b></li>
-     *              </ul>
-     *          <li>If 2 specifiers:</li>
-     *              <ul>
-     *                  <li>add runNumber according to first specifier</li>
-     *                  <li>remove second specifier</li>
-     *                  <li>for multiple streams, streamId is tacked onto the end of the file name as <b>.&lt;streamId&gt;</b></li>
-     *              </ul>
-     *          <li>If 3 specifiers:</li>
-     *              <ul>
-     *                  <li>add runNumber according to first specifier</li>
-     *                  <li>add streamId according to second specifier</li>
-     *                  <li>remove third specifier</li>
-     *              </ul>
-     *          </ul>
-     *  </ul>
+     *   <li>If file is to be split:
+     *     <ul>
+     *       <li>If no specifiers:
+     *         <ul>
+     *           <li>for one stream, splitNumber is tacked onto the end of the file name as <b>.&lt;splitNumber&gt;</b></li>
+     *           <li>for multiple streams, streamId and splitNumber are tacked onto the end of the file name
+     *               as <b>.&lt;streamId&gt;.&lt;splitNumber&gt;</b></li>
+     *           <li>No run numbers are ever tacked on without a specifier </li>
+     *         </ul>
+     *       </li>
+     *       <li>If 1 specifier:
+     *         <ul>
+     *           <li>add runNumber according to specifier</li>
+     *           <li>for one stream, splitNumber is tacked onto the end of the file name as <b>.&lt;splitNumber&gt;</b></li>
+     *           <li>for multiple streams, streamId and splitNumber are tacked onto the end of the file name
+     *               as <b>.&lt;streamId&gt;.&lt;splitNumber&gt;</b></li>
+     *         </ul>
+     *       </li>
+     *       <li>If 2 specifiers:
+     *         <ul>
+     *           <li>add runNumber according to first specifier</li>
+     *           <li>for one stream, add splitNumber according to second specifier</li>
+     *           <li>for multiple streams, add splitNumber according to second specifier, but place
+     *               <b>&lt;streamId&gt;.</b> just before the splitNumber</li>
+     *         </ul>
+     *       </li>
+     *       <li>If 3 specifiers:
+     *         <ul>
+     *           <li>add runNumber according to first specifier</li>
+     *           <li>add streamId according to second specifier add splitNumber according to third specifier</li>
+     *         </ul>
+     *       </li>
+     *     </ul>
+     *   </li>
+     *   <li>If file is NOT split:
+     *     <ul>
+     *       <li>If no specifiers:
+     *         <ul>
+     *           <li>streamId is tacked onto the end of the file name as <b>.&lt;streamId&gt;</b></li>
+     *           <li>No run numbers are ever tacked on without a specifier.</li>
+     *         </ul>
+     *       </li>
+     *       <li>If 1 specifier:
+     *         <ul>
+     *           <li>add runNumber according to specifier</li>
+     *           <li>for multiple streams, streamId is tacked onto the end of the file name as .<b>&lt;streamId&gt;</b></li>
+     *         </ul>
+     *       </li>
+     *       <li>If 2 specifiers:
+     *         <ul>
+     *           <li>add runNumber according to first specifier</li>
+     *           <li>remove second specifier</li>
+     *           <li>for multiple streams, streamId is tacked onto the end of the file name as <b>.&lt;streamId&gt;</b></li>
+     *         </ul>
+     *       </li>
+     *       <li>If 3 specifiers:
+     *         <ul>
+     *           <li>add runNumber according to first specifier</li>
+     *           <li>add streamId according to second specifier</li>
+     *           <li>remove third specifier</li>
+     *         </ul>
+     *       </li>
+     *     </ul>
+     *   </li>
+     * </ul>
      *
      * If there are more than 3 specifiers, <b>NO SUBSTITUTIONS ARE DONE on the extra specifiers</b>.
      *


### PR DESCRIPTION
Update the javadoc github action to use `mvn` instead of `ant` for document generation